### PR TITLE
Implement replication through traits

### DIFF
--- a/jasondb/Cargo.toml
+++ b/jasondb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jasondb"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "MIT"
 homepage = "https://github.com/w-henderson/JasonDB"

--- a/jasondb/src/error.rs
+++ b/jasondb/src/error.rs
@@ -15,6 +15,8 @@ pub enum JasonError {
     InvalidKey,
     /// The JSON value was invalid.
     JsonError,
+    /// An error occurred with a replica.
+    ReplicaError,
     /// An unknown error occurred.
     Unknown,
 }

--- a/jasondb/src/lib.rs
+++ b/jasondb/src/lib.rs
@@ -5,6 +5,7 @@
 
 mod database;
 pub mod error;
+pub mod replica;
 pub mod sources;
 mod util;
 

--- a/jasondb/src/replica.rs
+++ b/jasondb/src/replica.rs
@@ -1,0 +1,121 @@
+//! Provides replication functionality through traits.
+
+use crate::error::JasonError;
+use crate::sources::Source;
+use crate::Database;
+
+use humphrey_json::prelude::*;
+
+use std::sync::mpsc::{channel, Receiver, Sender};
+use std::thread::{spawn, JoinHandle};
+
+/// Represents a replica of a database.
+///
+/// The type parameter `T` represents the datatype of the database. However, since the replica is not necessarily
+///   using Rust types, the replica handles only the serialized JSON version of the value.
+pub trait Replica<T>: Send + 'static {
+    /// Replicate the change to the replica.
+    ///
+    /// The value is passed as the JSON representation of the value.
+    fn set(&mut self, key: &str, value: &str) -> Result<(), JasonError>;
+}
+
+/// Manages replication to a replica.
+pub(crate) enum Replicator<T> {
+    /// A synchronous replica.
+    Sync(Box<dyn Replica<T> + Send>),
+
+    /// An asynchronous replica which manages a thread and a channel for communication.
+    Async {
+        /// The thread which manages the replica.
+        thread: Option<JoinHandle<()>>,
+        /// A sender to send messages to the thread.
+        sender: Sender<ReplicationMessage>,
+    },
+}
+
+/// Represents a message to be sent to an asynchronous replica management thread.
+pub(crate) enum ReplicationMessage {
+    /// Indicates that the thread should replicate this write.
+    Replicate(String, String),
+    /// Indicates that the thread should shut down.
+    Shutdown,
+}
+
+impl<T> Replicator<T>
+where
+    T: 'static,
+{
+    /// Creates a new synchronous replicator.
+    pub fn new<R>(replica: R) -> Self
+    where
+        R: Replica<T>,
+    {
+        Self::Sync(Box::new(replica))
+    }
+
+    /// Creates a new asynchronous replicator.
+    pub fn new_async<R>(mut replica: R) -> Self
+    where
+        R: Replica<T>,
+    {
+        let (tx, rx): (Sender<ReplicationMessage>, Receiver<ReplicationMessage>) = channel();
+
+        let handle = spawn(move || {
+            for msg in rx {
+                match msg {
+                    ReplicationMessage::Replicate(key, value) => {
+                        replica.set(&key, &value).unwrap();
+                    }
+                    ReplicationMessage::Shutdown => {
+                        break;
+                    }
+                }
+            }
+        });
+
+        Self::Async {
+            thread: Some(handle),
+            sender: tx,
+        }
+    }
+
+    /// Sets the key to the given value in the replica.
+    pub fn set(&mut self, key: &str, value: &str) -> Result<(), JasonError> {
+        match self {
+            Self::Sync(replica) => replica.set(key, value),
+            Self::Async { sender, .. } => {
+                let msg = ReplicationMessage::Replicate(key.to_string(), value.to_string());
+
+                sender.send(msg).map_err(|_| JasonError::ReplicaError)?;
+
+                Ok(())
+            }
+        }
+    }
+}
+
+impl<T> Drop for Replicator<T> {
+    fn drop(&mut self) {
+        match self {
+            Self::Sync(_) => (),
+            Self::Async { thread, sender } => {
+                sender.send(ReplicationMessage::Shutdown).unwrap();
+
+                if let Some(thread) = thread.take() {
+                    thread.join().unwrap();
+                }
+            }
+        }
+    }
+}
+
+impl<T, S> Replica<T> for Database<T, S>
+where
+    T: IntoJson + FromJson + Send + 'static,
+    S: Source + Send + 'static,
+{
+    fn set(&mut self, key: &str, value: &str) -> Result<(), JasonError> {
+        self.set_raw(key, value.as_bytes())
+    }
+}

--- a/jasondb/src/sources/file.rs
+++ b/jasondb/src/sources/file.rs
@@ -66,7 +66,15 @@ impl FileSource {
 
     /// Converts the file source into an in-memory source by copying the contents of the file into memory.
     ///
-    /// **Warning:** changes made to the new in-memory source will not be reflected in the original file source.
+    /// **Warning:** changes made to the new in-memory source will not be reflected in the original file source. If you're looking
+    ///   to have an in-memory database which remains synchronized with the original file source, add a replica to replicate writes
+    ///   back to the file, as follows:
+    ///
+    /// ```rs
+    /// let mut db = Database::open("database.jdb")?          // Open the file-based database
+    ///     .into_memory()?                                   // Copy into memory
+    ///     .with_replica(Database::open("database.jdb")?);   // Replicate subsequent writes back to the file
+    /// ```
     pub fn into_memory(mut self) -> Result<InMemory, JasonError> {
         let mut buf: Vec<u8> = Vec::with_capacity(self.len as usize);
 

--- a/jasondb/src/tests/mock.rs
+++ b/jasondb/src/tests/mock.rs
@@ -4,7 +4,7 @@ use crate::Database;
 
 use humphrey_json::prelude::*;
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Person {
     pub(crate) name: String,
     pub(crate) year_of_birth: u16,

--- a/jasondb/src/tests/mod.rs
+++ b/jasondb/src/tests/mod.rs
@@ -1,5 +1,7 @@
 mod file;
 mod in_memory;
 mod macros;
-mod mock;
 mod query;
+mod replica;
+
+mod mock;

--- a/jasondb/src/tests/replica.rs
+++ b/jasondb/src/tests/replica.rs
@@ -1,0 +1,147 @@
+use crate::error::JasonError;
+use crate::replica::Replica;
+use crate::sources::InMemory;
+use crate::Database;
+
+use crate::tests::mock::Person;
+
+use std::fs;
+use std::sync::mpsc::{channel, Sender};
+
+#[test]
+fn sync_replica() -> Result<(), JasonError> {
+    let mut database: Database<Person, InMemory> = Database::new_in_memory()
+        .with_index("yearOfBirth")?
+        .with_replica(Database::create("test_sync_replica.jdb")?);
+
+    let person_1 = Person::new("Elizabeth II", 1926);
+    let person_2 = Person::new("George VI", 1895);
+    let person_3 = Person::new("Edward VIII", 1894);
+
+    database.set("queen_elizabeth_ii", &person_1)?;
+    database.set("king_george_vi", &person_2)?;
+    database.set("king_edward_viii", &person_3)?;
+
+    assert_eq!(database.iter().count(), 3);
+    assert_eq!(database.get("queen_elizabeth_ii"), Ok(person_1.clone()));
+    assert_eq!(database.get("king_george_vi"), Ok(person_2.clone()));
+    assert_eq!(database.get("king_edward_viii"), Ok(person_3.clone()));
+
+    drop(database);
+
+    let mut database: Database<Person> = Database::open("test_sync_replica.jdb")?;
+
+    assert_eq!(database.iter().count(), 3);
+    assert_eq!(database.get("queen_elizabeth_ii"), Ok(person_1));
+    assert_eq!(database.get("king_george_vi"), Ok(person_2));
+    assert_eq!(database.get("king_edward_viii"), Ok(person_3));
+
+    fs::remove_file("test_sync_replica.jdb").unwrap();
+
+    Ok(())
+}
+
+#[test]
+fn async_replica() -> Result<(), JasonError> {
+    let mut database: Database<Person, InMemory> = Database::new_in_memory()
+        .with_index("yearOfBirth")?
+        .with_async_replica(Database::create("test_async_replica.jdb")?);
+
+    let person_1 = Person::new("Elizabeth II", 1926);
+    let person_2 = Person::new("George VI", 1895);
+    let person_3 = Person::new("Edward VIII", 1894);
+
+    database.set("queen_elizabeth_ii", &person_1)?;
+    database.set("king_george_vi", &person_2)?;
+    database.set("king_edward_viii", &person_3)?;
+
+    assert_eq!(database.iter().count(), 3);
+    assert_eq!(database.get("queen_elizabeth_ii"), Ok(person_1.clone()));
+    assert_eq!(database.get("king_george_vi"), Ok(person_2.clone()));
+    assert_eq!(database.get("king_edward_viii"), Ok(person_3.clone()));
+
+    drop(database);
+
+    let mut database: Database<Person> = Database::open("test_async_replica.jdb")?;
+
+    assert_eq!(database.iter().count(), 3);
+    assert_eq!(database.get("queen_elizabeth_ii"), Ok(person_1));
+    assert_eq!(database.get("king_george_vi"), Ok(person_2));
+    assert_eq!(database.get("king_edward_viii"), Ok(person_3));
+
+    fs::remove_file("test_async_replica.jdb").unwrap();
+
+    Ok(())
+}
+
+#[test]
+fn arbitrary_replica() -> Result<(), JasonError> {
+    struct ChannelReplica(Sender<(String, String)>);
+
+    impl<T> Replica<T> for ChannelReplica
+    where
+        T: Send + 'static,
+    {
+        fn set(&mut self, key: &str, value: &str) -> Result<(), JasonError> {
+            self.0
+                .send((key.to_string(), value.to_string()))
+                .map_err(|_| JasonError::Io)
+        }
+    }
+
+    let (tx_1, rx_1) = channel();
+    let (tx_2, rx_2) = channel();
+
+    let mut database: Database<Person, InMemory> = Database::new_in_memory()
+        .with_index("yearOfBirth")?
+        .with_replica(ChannelReplica(tx_1.clone()))
+        .with_async_replica(ChannelReplica(tx_2.clone()));
+
+    let person_1 = Person::new("Elizabeth II", 1926);
+    let person_2 = Person::new("George VI", 1895);
+    let person_3 = Person::new("Edward VIII", 1894);
+
+    database.set("queen_elizabeth_ii", &person_1)?;
+    database.set("king_george_vi", &person_2)?;
+    database.set("king_edward_viii", &person_3)?;
+
+    assert_eq!(database.iter().count(), 3);
+    assert_eq!(database.get("queen_elizabeth_ii"), Ok(person_1.clone()));
+    assert_eq!(database.get("king_george_vi"), Ok(person_2.clone()));
+    assert_eq!(database.get("king_edward_viii"), Ok(person_3.clone()));
+
+    drop(database);
+
+    for rx in [rx_1, rx_2] {
+        assert_eq!(
+            rx.try_recv(),
+            Ok((
+                "queen_elizabeth_ii".to_string(),
+                humphrey_json::to_string(&person_1)
+            ))
+        );
+
+        assert_eq!(
+            rx.try_recv(),
+            Ok((
+                "king_george_vi".to_string(),
+                humphrey_json::to_string(&person_2)
+            ))
+        );
+
+        assert_eq!(
+            rx.try_recv(),
+            Ok((
+                "king_edward_viii".to_string(),
+                humphrey_json::to_string(&person_3)
+            ))
+        );
+
+        assert!(rx.try_recv().is_err());
+    }
+
+    drop(tx_1);
+    drop(tx_2);
+
+    Ok(())
+}


### PR DESCRIPTION
This implements basic synchronous and asynchronous replication through the `Replica` trait. This is implemented here for file-based databases, so in-memory databases can be replicated to disk.