### PR TITLE
Fix fundamental complexity issues

### DIFF
--- a/jasondb/src/database.rs
+++ b/jasondb/src/database.rs
@@ -366,7 +366,7 @@ where
             indexes
                 .get_mut(&indexed_value)
                 .ok_or(JasonError::InvalidKey)?
-                .retain(|i| *i != index);
+                .remove(&index);
         }
 
         self.source.write_entry(key.as_ref(), "null")?;

--- a/jasondb/src/database.rs
+++ b/jasondb/src/database.rs
@@ -10,7 +10,7 @@ use humphrey_json::prelude::*;
 use humphrey_json::Value;
 
 use std::borrow::Borrow;
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::marker::PhantomData;
 use std::path::Path;
 use std::vec::IntoIter;
@@ -59,7 +59,7 @@ where
     S: Source,
 {
     pub(crate) primary_indexes: HashMap<String, u64>,
-    pub(crate) secondary_indexes: HashMap<String, HashMap<Value, Vec<u64>>>,
+    pub(crate) secondary_indexes: HashMap<String, HashMap<Value, BTreeSet<u64>>>,
     pub(crate) source: S,
     pub(crate) replicas: Vec<Replicator<T>>,
     marker: PhantomData<T>,
@@ -300,31 +300,30 @@ where
             // Get the value used for the secondary index.
             let indexed_value = indexing::get_value(index_path, &value.borrow().to_json());
 
-            // Store whether the value has changed.
-            let changed_index_value = old_value
-                .as_ref()
-                .map(|v| v != &indexed_value)
-                .unwrap_or(false);
-            let vec = indexes.entry(indexed_value).or_insert_with(Vec::new);
+            let set = indexes
+                .entry(indexed_value.clone())
+                .or_insert_with(BTreeSet::new);
 
             // If the entire JSON value has changed but the secondary index value hasn't, remove the old index
             //   from the existing list.
             if let Some(old_index) = old_index {
-                vec.retain(|&i| i != old_index);
+                set.remove(&old_index);
             }
 
             // Add the new index to the list.
-            vec.push(index);
+            set.insert(index);
 
             // If the value has changed, check if the indexed value has also changed.
             if let Some(old_value) = &old_value {
                 let old_indexed_value = indexing::get_value(index_path, old_value);
 
-                if changed_index_value {
-                    let old_vec = indexes.entry(old_indexed_value).or_insert_with(Vec::new);
+                if old_indexed_value != indexed_value {
+                    let set = indexes
+                        .entry(old_indexed_value)
+                        .or_insert_with(BTreeSet::new);
 
                     // Remove the old index from the list.
-                    old_vec.retain(|&i| i != old_index.unwrap());
+                    set.remove(&old_index.unwrap());
                 }
             }
         }

--- a/jasondb/src/sources/file.rs
+++ b/jasondb/src/sources/file.rs
@@ -78,9 +78,7 @@ impl FileSource {
     pub fn into_memory(mut self) -> Result<InMemory, JasonError> {
         let mut buf: Vec<u8> = Vec::with_capacity(self.len as usize);
 
-        self.file
-            .seek(SeekFrom::Start(0))
-            .map_err(|_| JasonError::Io)?;
+        self.file.rewind().map_err(|_| JasonError::Io)?;
         self.file
             .read_to_end(&mut buf)
             .map_err(|_| JasonError::Io)?;
@@ -158,7 +156,7 @@ impl Source for FileSource {
             if v == b"null" {
                 indexes.remove(&key);
             } else {
-                indexes.insert(key, offset as u64);
+                indexes.insert(key, offset);
             }
 
             offset = new_offset;

--- a/jasondb/src/sources/file.rs
+++ b/jasondb/src/sources/file.rs
@@ -5,7 +5,7 @@ use crate::util::{indexing, quiet_assert};
 use humphrey_json::prelude::*;
 use humphrey_json::Value;
 
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::fs::{self, File, OpenOptions};
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
@@ -171,8 +171,8 @@ impl Source for FileSource {
         &mut self,
         k: impl AsRef<str>,
         primary_indexes: &HashMap<String, u64>,
-    ) -> Result<HashMap<Value, Vec<u64>>, JasonError> {
-        let mut indexes: HashMap<Value, Vec<u64>> = HashMap::new();
+    ) -> Result<HashMap<Value, BTreeSet<u64>>, JasonError> {
+        let mut indexes: HashMap<Value, BTreeSet<u64>> = HashMap::new();
 
         for i in primary_indexes.values() {
             let (_, v) = self.read_entry(*i)?;
@@ -180,12 +180,10 @@ impl Source for FileSource {
             let value = Value::parse(json).map_err(|_| JasonError::JsonError)?;
             let indexed_value = indexing::get_value(k.as_ref(), &value);
 
-            indexes.entry(indexed_value).or_insert(vec![]).push(*i);
-        }
-
-        // We sort the indexes to optimise queries.
-        for vec in indexes.values_mut() {
-            vec.sort_unstable();
+            indexes
+                .entry(indexed_value)
+                .or_insert_with(BTreeSet::new)
+                .insert(*i);
         }
 
         Ok(indexes)

--- a/jasondb/src/sources/mod.rs
+++ b/jasondb/src/sources/mod.rs
@@ -11,7 +11,7 @@ use crate::error::JasonError;
 use humphrey_json::prelude::*;
 use humphrey_json::Value;
 
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 
 /// Represents a backend source for the database.
 ///
@@ -33,7 +33,7 @@ pub trait Source {
         &mut self,
         k: impl AsRef<str>,
         indexes: &HashMap<String, u64>,
-    ) -> Result<HashMap<Value, Vec<u64>>, JasonError>;
+    ) -> Result<HashMap<Value, BTreeSet<u64>>, JasonError>;
 
     /// Compacts the database, removing all deleted entries to save space.
     fn compact(&mut self, indexes: &HashMap<String, u64>) -> Result<(), JasonError>;

--- a/jasondb/src/tests/file/raw_data.rs
+++ b/jasondb/src/tests/file/raw_data.rs
@@ -119,10 +119,10 @@ fn index_on() -> Result<(), Box<dyn std::error::Error>> {
     assert!(!men.contains(&elizabeth_ii));
 
     let women = index_on_gender.get(&json!("female")).unwrap();
-    assert_eq!(*women, vec![elizabeth_ii]);
+    assert_eq!(*women, [elizabeth_ii].iter().cloned().collect());
 
     let born_in_1895 = index_on_year.get(&json!(1895)).unwrap();
-    assert_eq!(*born_in_1895, vec![george_vi]);
+    assert_eq!(*born_in_1895, [george_vi].iter().cloned().collect());
 
     let born_in_1900 = index_on_year.get(&json!(1900));
     assert!(born_in_1900.is_none());

--- a/jasondb/src/tests/file/raw_data.rs
+++ b/jasondb/src/tests/file/raw_data.rs
@@ -3,7 +3,7 @@ use crate::sources::{FileSource, Source};
 use humphrey_json::prelude::*;
 
 use std::fs::{self, File};
-use std::io::{Read, Seek, SeekFrom, Write};
+use std::io::{Read, Seek, Write};
 
 #[test]
 fn read_write() {
@@ -59,7 +59,7 @@ fn compact() {
     database.compact(&indexes).unwrap();
 
     let mut buf: Vec<u8> = vec![0; database.len as usize];
-    database.file.seek(SeekFrom::Start(0)).unwrap();
+    database.file.rewind().unwrap();
     database.file.read_exact(&mut buf).unwrap();
     assert!(
         buf == b"\x04\0\0\0\0\0\0\0key2\x07\0\0\0\0\0\0\0value 2\x04\0\0\0\0\0\0\0key1\x0c\0\0\0\0\0\0\0overwritten!" ||

--- a/jasondb/src/tests/in_memory/raw_data.rs
+++ b/jasondb/src/tests/in_memory/raw_data.rs
@@ -86,10 +86,10 @@ fn index_on() -> Result<(), Box<dyn std::error::Error>> {
     assert!(!men.contains(&elizabeth_ii));
 
     let women = index_on_gender.get(&json!("female")).unwrap();
-    assert_eq!(*women, vec![elizabeth_ii]);
+    assert_eq!(*women, [elizabeth_ii].iter().cloned().collect());
 
-    let born_in_1895 = index_on_year.get(&json!(1895)).unwrap();
-    assert_eq!(*born_in_1895, vec![george_vi]);
+    let born_in_1895: &std::collections::BTreeSet<u64> = index_on_year.get(&json!(1895)).unwrap();
+    assert_eq!(*born_in_1895, [george_vi].iter().cloned().collect());
 
     let born_in_1900 = index_on_year.get(&json!(1900));
     assert!(born_in_1900.is_none());

--- a/jasondb/src/tests/index.rs
+++ b/jasondb/src/tests/index.rs
@@ -6,7 +6,7 @@ use crate::tests::mock::Person;
 
 use humphrey_json::Value;
 
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 
 #[test]
 fn test_add_new() -> Result<(), JasonError> {
@@ -32,18 +32,33 @@ fn test_add_new() -> Result<(), JasonError> {
     let name_index = database.secondary_indexes.get("name").unwrap();
     let year_of_birth_index = database.secondary_indexes.get("year_of_birth").unwrap();
 
-    let expected_name_index: HashMap<Value, Vec<u64>> = [
-        (Value::String("A".to_string()), vec![index_1]),
-        (Value::String("B".to_string()), vec![index_2]),
-        (Value::String("C".to_string()), vec![index_3]),
-        (Value::String("D".to_string()), vec![index_4]),
+    let expected_name_index: HashMap<Value, BTreeSet<u64>> = [
+        (
+            Value::String("A".to_string()),
+            [index_1].iter().cloned().collect(),
+        ),
+        (
+            Value::String("B".to_string()),
+            [index_2].iter().cloned().collect(),
+        ),
+        (
+            Value::String("C".to_string()),
+            [index_3].iter().cloned().collect(),
+        ),
+        (
+            Value::String("D".to_string()),
+            [index_4].iter().cloned().collect(),
+        ),
     ]
     .into();
 
-    let expected_year_of_birth_index: HashMap<Value, Vec<u64>> = [
-        (Value::Number(2000.0), vec![index_1, index_2]),
-        (Value::Number(2001.0), vec![index_3]),
-        (Value::Number(2002.0), vec![index_4]),
+    let expected_year_of_birth_index: HashMap<Value, BTreeSet<u64>> = [
+        (
+            Value::Number(2000.0),
+            [index_1, index_2].iter().cloned().collect(),
+        ),
+        (Value::Number(2001.0), [index_3].iter().cloned().collect()),
+        (Value::Number(2002.0), [index_4].iter().cloned().collect()),
     ]
     .into();
 
@@ -80,18 +95,33 @@ fn test_update() -> Result<(), JasonError> {
     let name_index = database.secondary_indexes.get("name").unwrap();
     let year_of_birth_index = database.secondary_indexes.get("year_of_birth").unwrap();
 
-    let expected_name_index: HashMap<Value, Vec<u64>> = [
-        (Value::String("A".to_string()), vec![index_1]),
-        (Value::String("B".to_string()), vec![index_2]),
-        (Value::String("C".to_string()), vec![index_3]),
-        (Value::String("D".to_string()), vec![index_4]),
+    let expected_name_index: HashMap<Value, BTreeSet<u64>> = [
+        (
+            Value::String("A".to_string()),
+            [index_1].iter().cloned().collect(),
+        ),
+        (
+            Value::String("B".to_string()),
+            [index_2].iter().cloned().collect(),
+        ),
+        (
+            Value::String("C".to_string()),
+            [index_3].iter().cloned().collect(),
+        ),
+        (
+            Value::String("D".to_string()),
+            [index_4].iter().cloned().collect(),
+        ),
     ]
     .into();
 
-    let expected_year_of_birth_index: HashMap<Value, Vec<u64>> = [
-        (Value::Number(2000.0), vec![index_2]),
-        (Value::Number(2001.0), vec![index_3, index_1]),
-        (Value::Number(2002.0), vec![index_4]),
+    let expected_year_of_birth_index: HashMap<Value, BTreeSet<u64>> = [
+        (Value::Number(2000.0), [index_2].iter().cloned().collect()),
+        (
+            Value::Number(2001.0),
+            [index_3, index_1].iter().cloned().collect(),
+        ),
+        (Value::Number(2002.0), [index_4].iter().cloned().collect()),
     ]
     .into();
 


### PR DESCRIPTION
Secondary indexes now use `BTreeSet<u64>` instead of `Vec<u64>` to prevent linear-time `set` and `delete` operations. I chose `BTreeSet` over `HashSet` because optimised queries require ordered lists of offsets, although this is probably still open to change.